### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,10 @@ a) Prerequisites
 		libcurl4-openssl-dev
 
         sudo apt-get build-dep qt4-qmake
+        
+  * If you have a 64-bit system, don't forget to install 32-bit libraries to run cmake
+	
+        sudo apt-get install ia32-libs
 
   * cmake version 2.8.7 will be fetched and used for the build; there is no need to install it.
 


### PR DESCRIPTION
`cmake` fails to run on 64-bit system

```
~/luna-desktop-binaries/cmake/bin$ ./cmake
bash: ./cmake: No such file or directory

~/luna-desktop-binaries/cmake/bin$ file cmake
cmake: ELF 32-bit LSB executable, Intel 80386, version 1 (SYSV), dynamically linked (uses shared libs), for GNU/Linux 2.0.0, stripped
```

```
~/luna-desktop-binaries/cmake/bin$ sudo apt-get install ia32-libs
~/luna-desktop-binaries/cmake/bin$ ./cmake
cmake version 2.8.7
```
