### PR TITLE
Abstract Ubuntu dependencies into scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,44 +16,19 @@ How to Build on Ubuntu Linux
 
 Prerequisites
 -------------
-
   * Ensure you have a fast and reliable internet connection since you'll be downloading about 500MB
-
   * Ensure you have at least 4GB of available disk space
+  * Install dependencies needed to build (and run) Open webOS on the desktop by running the following script:
 
-  * Install the following components needed to build (and run) Open webOS on the desktop by typing the following:
+        $ ./prerequisites.sh
 
-        $ sudo apt-get update
-
-        $ sudo apt-get install git git-core pkg-config make autoconf libtool g++ \
-		tcl unzip libyajl-dev libyajl1 qt4-qmake libsqlite3-dev curl
-
-        $ sudo apt-get install gperf bison libglib2.0-dev libssl-dev libxi-dev \
-		libxrandr-dev libxfixes-dev libxcursor-dev libfreetype6-dev \
-		libxinerama-dev libgl1-mesa-dev libgstreamer0.10-dev \
-		libgstreamer-plugins-base0.10-dev flex libicu-dev
-
-        $ sudo apt-get install libboost-system-dev libboost-filesystem-dev \
-		libboost-regex-dev libboost-program-options-dev liburiparser-dev \
-		libc-ares-dev libsigc++-2.0-dev libglibmm-2.4-dev libdb4.8-dev \
-		libcurl4-openssl-dev
-
-        $ sudo apt-get install xcb libx11-xcb-dev libxcb-sync0-dev \
-		libxcb1-dev libxcb-keysyms1-dev libxcb-image0-dev libxcb-render-util0-dev \
-		libxcb-icccm1-dev
-
-        $ sudo apt-get build-dep qt4-qmake
-
-  * The components listed above are valid for both Ubuntu 11.04 and 12.04, except for libxcb-icccm1-dev which is libxcb-icccm4-dev on 12.04
-
-  * CMake version 2.8.7 will be fetched and used for the build; there is no need to install it.
+Note that CMake version 2.8.7 will automatically be fetched and used for the build. There is no need to install it.
 
 
 Downloading
 -----------
 
 Download the zip file and unzip it into an empty directory or better yet, "git clone" the repository.
-
 
 Building Open webOS
 -------------------

--- a/prerequisites.sh
+++ b/prerequisites.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+sudo apt-get update
+
+sudo apt-get install -y git git-core pkg-config make autoconf libtool g++ tcl unzip libyajl-dev libyajl1 qt4-qmake libsqlite3-dev curl
+
+sudo apt-get install -y gperf bison libglib2.0-dev libssl-dev libxi-dev libxrandr-dev libxfixes-dev libxcursor-dev libfreetype6-dev libxinerama-dev libgl1-mesa-dev libgstreamer0.10-dev libgstreamer-plugins-base0.10-dev flex libicu-dev
+
+sudo apt-get install -y libboost-system-dev libboost-filesystem-dev libboost-regex-dev libboost-program-options-dev liburiparser-dev libc-ares-dev libsigc++-2.0-dev libglibmm-2.4-dev libdb4.8-dev libcurl4-openssl-dev
+
+sudo apt-get install -y xcb libx11-xcb-dev libxcb-sync0-dev libxcb1-dev libxcb-keysyms1-dev libxcb-image0-dev libxcb-render-util0-dev
+
+LSB=`lsb_release -r`
+VERSION=${LSB:(-5)}
+
+if [ "$VERSION" == "11.04" ]; then
+    sudo apt-get install -y libxcb-icccm1-dev
+elif [ "$VERSION" == "12.04" ]; then
+    sudo apt-get install -y libxcb-icccm4-dev
+fi
+
+sudo apt-get build-dep qt4-qmake
+


### PR DESCRIPTION
I moved the dependencies into separate install scripts to make it easier to get started. The scripts contain the differences between 11.04 and 12.04 (the thing with libxcb-icccm1-dev and libxcb-icccm4-dev) and all common dependencies are placed into install-deps-common.sh

This is also good when something changes, we only need to update the install scripts and we also have a clean separation between 11.04 and 12.04 in case anything else changes. Also, if another environment is supported we can just add another dependency script and don't have to update the README
